### PR TITLE
bug in the code for nested case?

### DIFF
--- a/src/recursion.cpp
+++ b/src/recursion.cpp
@@ -229,7 +229,7 @@ void class_tree::update()
         }
         
         CHI_CURR += n_states;
-        DATA_CURR += n_groups;
+        DATA_CURR += sum(n_subgroups);
         if( return_global_null == true)
           PSI_CURR++;
         if( return_tree == true)


### PR DESCRIPTION
Hi Jacopo,

Is this a bug for the nested case? It seems that the data pointer is should be moved by the total number of subgroups. The bug makes the posterior null probabilities very close to 1.

-Li
