### PR TITLE
Bug when return_tree=FALSE

### DIFF
--- a/R/mrs.R
+++ b/R/mrs.R
@@ -40,7 +40,7 @@ mrs <- function( X,
                  eta = 0.3, 
                  alpha = 0.5,
                  return_global_null = TRUE,
-                 return_tree = TRUE,
+                 return_tree = TRUE, ## Please check, when return_tree = FALSE, MRS doesn't fit. Gets error message about data matrix.
                  min_n_node = 0
                 )
 {


### PR DESCRIPTION
When return_tree = FALSE, mrs doesn't run, gets the following error message

Error in matrix(unlist(ans$RepresentativeTree$EffectSizes), nrow = length(ans$RepresentativeTree$Levels),  : 
  'data' must be of a vector type, was 'NULL'
