### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ Rcpp::List fitMRScpp( arma::mat X,
   // sub-gorups label for each observation (used in dANOVA)
   vec H(n_tot); H.fill(1);
   // prior on parameter nu (used in dANOVA)
-  arma::vec nu_vec(1); nu_vec << 1 ;   
+  arma::vec nu_vec({1});
   vec a = 1.0 / (Omega.col(1) - Omega.col(0));
   vec b = - Omega.col(0) % a;
   // Initialize matrix of observations normalized to the p-dimensional hypercube

--- a/src/recursion.cpp
+++ b/src/recursion.cpp
@@ -641,8 +641,7 @@ Rcpp::List class_tree::compute_m_anova(INDEX_TYPE& I, int level, int d)
   vec m_nus(n_grid + 1); m_nus.fill(log(0.0));
   mat thetas(n_groups, n_grid); thetas.fill(0.5);
   int n_grid_theta = 4;
-  vec theta0(n_grid_theta);
-  theta0 << 0.125 << 0.375 << 0.625 << 0.875 ;
+  vec theta0({ 0.125, 0.375, 0.625, 0.875});
 
   vec data_0( sum(n_subgroups) ); 
   vec data_1( sum(n_subgroups) );


### PR DESCRIPTION
Two simple changes to update RcppArmadillo use from the now deprecated `<<` initialization to brace initialization allowed since C++11 and long been the minimal standard with R too.  It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391